### PR TITLE
Fix abortion notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-#CHANGELOG
+# CHANGELOG
+
+## Async 0.0.5
+
+- Fix `asyncBar2` behaviour where abortion notification was dismissed before the abortion was concluded. The `removeNotification` is now called on `finalize` method.
 
 ## Async 0.0.4
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: async
 Type: Package
 Title: Async
-Version: 0.0.4
+Version: 0.0.5
 Authors@R: 
     c(person(
       given = "Igor",

--- a/R/asyncBar2.R
+++ b/R/asyncBar2.R
@@ -135,8 +135,7 @@ asyncBar2 = R6::R6Class(classname = 'asyncBar2',
                               if( isTRUE(val == 7777) |
                                   isTRUE(val == max.val) |
                                   isTRUE(private$n.rep > private$max.rep) ) {
-
-                                shiny::removeNotification(private$notid)
+                                #shiny::removeNotification(private$notid)
                                 private$interrupt_client()
 
                               } else {
@@ -174,10 +173,10 @@ asyncBar2 = R6::R6Class(classname = 'asyncBar2',
                               if(isTRUE(not.c)){
                                 notid = private$notid
                                 shiny::showNotification(not.msg,
-                                               type = "warning",
-                                               id = notid,
-                                               duration = NULL,
-                                               closeButton = FALSE)
+                                                        type = "warning",
+                                                        id = notid,
+                                                        duration = NULL,
+                                                        closeButton = FALSE)
                               }
                               private$async$interrupt()
 
@@ -271,6 +270,7 @@ asyncBar2 = R6::R6Class(classname = 'asyncBar2',
                           #' Close all routines of async bar.
                           finalize = function(){
                             private$interrupt_client()
+                            shiny::removeNotification(private$notid)
                           }
                         )
 )

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![logo](https://github.com/meantrix/async/blob/develop/inst/header_transparente_colorido.png)
 
 <!--- These are examples. See https://shields.io for others or to customize this set of shields. You might want to include dependencies, project status and licence info here --->
-[![version](https://img.shields.io/badge/version-0.0.4-green.svg)](https://semver.org)
+[![version](https://img.shields.io/badge/version-0.0.5-green.svg)](https://semver.org)
 
 
 async is a `tool` for passing messages between some R processes 

--- a/examples/progress_bar_cancel2.R
+++ b/examples/progress_bar_cancel2.R
@@ -1,0 +1,59 @@
+library(shiny)
+library(promises)
+library(future)
+library(async)
+library(shinyWidgets)
+plan(multiprocess)
+
+ui <- tagList(shinyjs::useShinyjs(),
+              fluidPage(titlePanel("Long Run Stoppable Async")))
+
+
+server <- function(input, output, session) {
+
+  N <- 100
+  asy1 = async$new(
+    reactive = TRUE,
+    auto.finish = FALSE,
+    lower = 0,
+    upper = 100
+  )
+  bar = asyncBar2$new(
+    async = asy1,
+    id = '01',
+    msg = 'fixed message',
+    max.rep = 20,
+    interval = 1000
+  )
+  bar$progress(session, input)
+  bar$cancel(session, input, not.msg = "Aborting Process...")
+
+  result <- future({
+    print("Running...")
+    for (i in 1:N) {
+      # Long Running Task
+      Sys.sleep(8)
+      # Notify status file of progress
+      asy1$set(100 * i / N, detail = paste0("...", as.character(100 * i /
+                                                                  N), "..."))
+    }
+    # Some results
+    quantile(rnorm(1000))
+  })
+
+  promises::then(result,
+                 onFulfilled = function(res) {
+                   showNotification("Future Finished", type = "message")
+                   print(res)
+                   bar$finalize()
+                 },
+                 onRejected = function(e) {
+                   showNotification(e$message, type = "error")
+                   print(e$message)
+                   bar$finalize()
+                 })
+
+}
+
+# Run the application
+shinyApp(ui = ui, server = server)

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -11,6 +11,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{magrittr}{\code{\link[magrittr]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}}
 }}
 


### PR DESCRIPTION
### Async 0.0.5

- Fix `asyncBar2` behaviour where abortion notification was dismissed before the abortion was concluded. The `removeNotification` is now called on `finalize` method.

Closes https://github.com/meantrix/geotrix_app/issues/340